### PR TITLE
Add multicall contract address for X Layer

### DIFF
--- a/src/chains/definitions/xLayer.ts
+++ b/src/chains/definitions/xLayer.ts
@@ -17,4 +17,10 @@ export const xLayer = /*#__PURE__*/ defineChain({
       url: 'https://www.oklink.com/xlayer',
     },
   },
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 47416
+    }
+  },
 })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Adds the multicall3 contract address for X Layer mainnet, which is: https://www.okx.com/web3/explorer/xlayer/address/0xcA11bde05977b3631167028862bE2a173976CA11

Documented in the multicall3 deployments.json file:
https://github.com/mds1/multicall/blob/main/deployments.json#L1147-L1151

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

